### PR TITLE
Update to Zephyr v3.3.0 (from v2.7.0)

### DIFF
--- a/.github/actions/action-zephyr/Dockerfile
+++ b/.github/actions/action-zephyr/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM ghcr.io/bcdevices/zephyr:2.7.0-1
+FROM ghcr.io/bcdevices/zephyr:v3.3.0-7
 
 RUN pip3 install --no-cache-dir nrfutil
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2020-2021 Blue Clover Devices
 
-FROM ghcr.io/bcdevices/zephyr:2.7.0-1
+FROM ghcr.io/bcdevices/zephyr:v3.3.0-7
 
 RUN pip3 install --no-cache-dir nrfutil
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DOCKER_BUILD_ARGS += --network=host
 DOCKER_RUN_ARGS :=
 DOCKER_RUN_ARGS += --network=none
 
-ZEPHYR_TAG := 2.7.0
+ZEPHYR_TAG := 3.3.0
 ZEPHYR_SYSROOT := /usr/src/zephyr-$(ZEPHYR_TAG)/zephyr
 ZEPHYR_USRROOT := $(HOME)/src/zephyr-$(ZEPHYR_TAG)/zephyr
 


### PR DESCRIPTION
Build against Zephyr v3.3.0, instead of v2.7.0.   This includes several updates to the underlying BLE stack used for BLE testing.

- [3.3 Release notes](https://docs.zephyrproject.org/3.3.0/releases/release-notes-3.3.html)
- [3.2 Release notes](https://docs.zephyrproject.org/3.3.0/releases/release-notes-3.2.html)
- [3.1 Release notes](https://docs.zephyrproject.org/3.3.0/releases/release-notes-3.1.html)
- [3.0 Release notes](https://docs.zephyrproject.org/3.3.0/releases/release-notes-3.1.html)