### PR TITLE
PLTOS-275: Adafruit Feather nRF52840 Express

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build and Upload
-    runs-on: ubuntu-latest
+    runs-on: zephyr-runner
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ endif
 ZEPHYR_BOARD_ROOT := $(BASE_PATH)
 
 BOARDS :=
+BOARDS += adafruit_feather_nrf52840
 BOARDS += nrf52840dk_nrf52840
 BOARDS += nrf52840dongle_nrf52840
 
@@ -95,6 +96,7 @@ endif
 
 .PHONY: dist
 dist: dist-clean dist-prep build
+	install -m 666 build.adafruit_feather_nrf52840/hci_usb_h4/zephyr/zephyr.hex dist/hci_usb_h4-adafruit_feather_nrf52840-$(ZEPHYR_TAG).hex
 	install -m 666 build.nrf52840dk_nrf52840/hci_usb_h4/zephyr/zephyr.hex dist/hci_usb_h4-nrf52840dk-$(ZEPHYR_TAG).hex
 	install -m 666 build.nrf52840dongle_nrf52840/hci_usb_h4/zephyr/zephyr.hex dist/hci_usb_h4-nrf52840dongle-$(ZEPHYR_TAG).hex
 	install -m 666 build.nrf52840dongle_nrf52840/hci_usb_h4/zephyr/zephyr-dfu.zip dist/hci_usb_h4-nrf52840dongle-$(ZEPHYR_TAG)-dfu.zip


### PR DESCRIPTION
Build BLE probe firmware binary for the Adafruit Feather nRF52840 Express module.

https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/