### PR TITLE
PLTOS-275: Resolve nRF5240 Dongle USB Connection Issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(hci_usb_h4)
+
+target_sources(app PRIVATE src/main.c)

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,7 @@ TARGETS += build.nrf52840dongle_nrf52840/hci_usb_h4/zephyr/zephyr-dfu.zip
 build.%/hci_usb_h4/zephyr/zephyr.hex: check-zephyr
 	source $(ZEPHYR_ROOT)/zephyr-env.sh ; \
 	west build --build-dir build.$*/hci_usb_h4 --pristine auto \
-	--board $* $(ZEPHYR_ROOT)/samples/bluetooth/hci_usb_h4 \
-	-DCONFIG_BT_CTLR_DTM_HCI=y
+	--board $*
 
 %/zephyr-dfu.zip: %/zephyr.hex
 	nrfutil pkg generate --hw-version 52 --sd-req=0x00 \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Firmware images for BLE dongles, allowing these to be used for
 [BLE Testing](https://docs.pltcloud.com/TestPlanReference/ble/)
 with the [PLT-300A](https://bcdevices.com/pages/plt-300a).
 
+Uses the HCI USB H4 interface provided by the Zephyr RTOS Bluetooth stack.
+
 - [RF52840-DONGLE (PCA10059)](https://docs.pltcloud.com/peripheral/ble/nrf52840-dongle/)
   **hci_usb_h4** firmware image
   ([DFU](https://github.com/bcdevices/ly11-ble-fw/releases/download/v1.1.0/hci_usb_h4-nrf52840dongle-2.7.0-dfu.zip))
@@ -12,10 +14,6 @@ with the [PLT-300A](https://bcdevices.com/pages/plt-300a).
 - [nRF52840DK (PCA10056)](https://docs.zephyrproject.org/3.0.0/boards/arm/nrf52840dk_nrf52840/doc/index.html)
   **hci_usb_h4** firmware image
   ([.hex](https://github.com/bcdevices/ly11-ble-fw/releases/download/v1.1.0/hci_usb_h4-nrf52840dk-2.7.0.hex))
-
-These **hci_usb_h4** firmware images can be built from the source code of the
-[Bluetooth: HCI H4 over USB](https://docs.zephyrproject.org/2.7.0/samples/bluetooth/hci_usb_h4/README.html)
-sample project of the [Zephyr](https://zephyrproject.org/) RTOS.
 
 ## Dongle Programming
 

--- a/boards/nrf52840dongle_nrf52840.conf
+++ b/boards/nrf52840dongle_nrf52840.conf
@@ -1,0 +1,3 @@
+# USB CDC is on by default in nRF52840 Dongle. It interferes with BLE HCI interface, so we turn it off.
+CONFIG_BOARD_SERIAL_BACKEND_CDC_ACM=n
+CONFIG_USB_CDC_ACM=n

--- a/boards/nrf52840dongle_nrf52840.overlay
+++ b/boards/nrf52840dongle_nrf52840.overlay
@@ -1,0 +1,20 @@
+/ {
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,uart-mcumgr = &uart0;
+		zephyr,bt-mon-uart = &uart0;
+		zephyr,bt-c2h-uart = &uart0;
+	};
+};
+
+zephyr_udc0: &usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+
+	cdc_acm_uart: cdc_acm_uart {
+		compatible = "zephyr,cdc-acm-uart";
+		status = "disabled";
+	};
+};
+

--- a/prj.conf
+++ b/prj.conf
@@ -1,0 +1,14 @@
+CONFIG_STDOUT_CONSOLE=y
+CONFIG_GPIO=y
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+CONFIG_USB_DEVICE_INITIALIZE_AT_BOOT=n
+
+CONFIG_USB_DEVICE_STACK=y
+CONFIG_USB_DEVICE_PID=0x000C
+CONFIG_USB_DEVICE_BT_H4=y
+CONFIG_BT_CTLR_DTM_HCI=y
+
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Blue Clover
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/usb/usb_device.h>
+
+int main(void)
+{
+	int ret;
+
+	ret = usb_enable(NULL);
+	if (ret != 0) {
+		printk("Failed to enable USB");
+		return 0;
+	}
+
+	printk("BLE Dongle Firmware\n");
+	return 0;
+}


### PR DESCRIPTION
Determined that the USB CDC interface, which is enabled by default on the nRF52840 Dongle, was interfering with PLT-OS interaction.

* Moved application code and configuration into this repo for greater control.
* Override DTS and config for nRF52840 Dongle to turn off USB CDC.

Tested working with PLT-OS 1.10.7.