### PR TITLE
usb: product descriptor: encode version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ TARGETS += build.nrf52840dongle_nrf52840/hci_usb_h4/zephyr/zephyr-dfu.zip
 build.%/hci_usb_h4/zephyr/zephyr.hex: check-zephyr
 	source $(ZEPHYR_ROOT)/zephyr-env.sh ; \
 	west build --build-dir build.$*/hci_usb_h4 --pristine auto \
-	--board $*
+	--board $* \
+	-- -DCONFIG_USB_DEVICE_PRODUCT=\"$(PRJTAG)-v$(VERSION_TAG)\"
 
 %/zephyr-dfu.zip: %/zephyr.hex
 	nrfutil pkg generate --hw-version 52 --sd-req=0x00 \


### PR DESCRIPTION
Encode the firmware version in the USB *Product* descriptor string.

```console
$ lsusb
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               2.00
  bDeviceClass            0
  bDeviceSubClass         0
  bDeviceProtocol         0
  bMaxPacketSize0        64
  idVendor           0x2fe3 NordicSemiconductor
  idProduct          0x000c
  bcdDevice            3.05
  iManufacturer           1 ZEPHYR
  iProduct                2 ly11-ble-fw-v1.2.4
  iSerial                 3 6E1531D1CB5B6DC6
  :
```